### PR TITLE
QualifierProvider 의 의존성 정렬 추가 및 주입 시 주입 타입 보장 변경사항

### DIFF
--- a/modules/global-core/src/main/kotlin/kr/hqservice/framework/global/core/component/error/QualifierNotFoundException.kt
+++ b/modules/global-core/src/main/kotlin/kr/hqservice/framework/global/core/component/error/QualifierNotFoundException.kt
@@ -1,0 +1,3 @@
+package kr.hqservice.framework.global.core.component.error
+
+class QualifierNotFoundException : RuntimeException("qualifier not found")

--- a/modules/global-core/src/main/kotlin/kr/hqservice/framework/global/core/component/registry/AbstractComponentRegistry.kt
+++ b/modules/global-core/src/main/kotlin/kr/hqservice/framework/global/core/component/registry/AbstractComponentRegistry.kt
@@ -219,7 +219,7 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
             val parameterKClass = parameter.type.classifier as KClass<*>
             if (providedInstanceMap != null) {
                 val providedInstance =
-                    providedInstanceMap.filter { parameterKClass.isSuperclassOf(it.key) }.values.firstOrNull()
+                    providedInstanceMap.filter { parameterKClass == it.key }.values.firstOrNull()
                 if (providedInstance != null) {
                     return@map providedInstance
                 }

--- a/modules/global-core/src/main/kotlin/kr/hqservice/framework/global/core/component/registry/AbstractComponentRegistry.kt
+++ b/modules/global-core/src/main/kotlin/kr/hqservice/framework/global/core/component/registry/AbstractComponentRegistry.kt
@@ -4,6 +4,7 @@ import kr.hqservice.framework.global.core.component.handler.ComponentHandler
 import kr.hqservice.framework.global.core.component.handler.HQComponentHandler
 import kr.hqservice.framework.global.core.component.*
 import kr.hqservice.framework.global.core.component.error.*
+import kr.hqservice.framework.global.core.extension.print
 import org.koin.core.annotation.*
 import org.koin.core.component.KoinComponent
 import org.koin.core.definition.BeanDefinition
@@ -36,6 +37,7 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
     @Suppress("UNCHECKED_CAST")
     final override fun setup() {
         val componentClasses = mutableListOf<Class<*>>()
+        val qualifierProviderClasses = mutableListOf<Class<*>>()
         val unsortedComponentHandlers: MutableMap<KClass<*>, KClass<HQComponentHandler<*>>> = mutableMapOf()
         for (clazz in getAllComponentsToScan()) {
             val annotations = clazz.annotations
@@ -46,15 +48,12 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
             } else if (annotations.filterIsInstance<Component>().isNotEmpty()) {
                 componentClasses.add(clazz)
             } else if (annotations.filterIsInstance<QualifierProvider>().isNotEmpty()) {
-                val key = annotations.filterIsInstance<QualifierProvider>().first().key
-                val qualifierProvider = callByInjectedParameters(
-                    clazz.kotlin.constructors.first(),
-                    getProvidedInstances()
-                ) as? MutableNamedProvider ?: throw IllegalStateException("not qualifier provider")
-                qualifierProviders[key] = qualifierProvider
+                qualifierProviderClasses.add(clazz)
             }
         }
-        val componentClassesQueue: ConcurrentLinkedQueue<KClass<*>> = ConcurrentLinkedQueue(componentClasses.map { it.kotlin })
+        val componentClassesQueue: ConcurrentLinkedQueue<KClass<*>> = ConcurrentLinkedQueue(
+            componentClasses.map { it.kotlin }
+        ).apply { addAll(qualifierProviderClasses.map { it.kotlin }) }
 
         // 사이즈가 같은 채로 그 큐의 사이즈만큼 반복됐다면, 더 이상 definition 이 없는것으로 판단 후 throw
         var componentExceptionCatchingStack = 0
@@ -66,8 +65,8 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
             }
 
             val constructor = component.constructors.first()
-            val instance = callByInjectedParameters(constructor, getProvidedInstances())
-            if (instance == null) {
+
+            fun back() {
                 componentClassesQueue.offer(component)
                 if (previousComponentQueueSize == componentClassesQueue.size) {
                     componentExceptionCatchingStack++
@@ -76,9 +75,32 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
                     throw NoBeanDefinitionsFoundException(componentClassesQueue.toList())
                 }
                 previousComponentQueueSize = componentClassesQueue.size
+            }
+
+            val instance = try {
+                callByInjectedParameters(constructor, getProvidedInstances())
+            } catch (exception: QualifierNotFoundException) {
+                back()
+                continue
+            }
+
+            if (instance == null) {
+                back()
+                continue
             } else {
-                componentInstances.addSafely(instance)
-                tryCreateBeanModule(component, instance)
+                try {
+                    tryCreateBeanModule(component, instance)
+                } catch (exception: QualifierNotFoundException) {
+                    back()
+                    continue
+                }
+                if (instance is HQComponent) {
+                    componentInstances.addSafely(instance)
+                } else if (instance is MutableNamedProvider) {
+                    val key = component.annotations.filterIsInstance<QualifierProvider>().first().key
+                    qualifierProviders[key] = instance
+                }
+
                 componentExceptionCatchingStack = 0
             }
         }
@@ -182,7 +204,14 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
         if (injectedParameters.any { it == null }) {
             return null
         }
-        return kFunction.call(*injectedParameters.toTypedArray())
+        return try {
+            kFunction.call(*injectedParameters.toTypedArray())
+        } catch (illegalArgumentException: IllegalArgumentException) {
+            kFunction.instanceParameter.print("instanceParameter: ")
+            kFunction.parameters.print("parameters: ")
+            injectedParameters.print("injectedParamaters: ")
+            throw illegalArgumentException
+        }
     }
 
     private fun injectParameters(kFunction: KFunction<*>, providedInstanceMap: Map<KClass<*>, *>? = null): List<Any?> {
@@ -190,7 +219,7 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
             val parameterKClass = parameter.type.classifier as KClass<*>
             if (providedInstanceMap != null) {
                 val providedInstance =
-                    providedInstanceMap.filter { parameterKClass.isSubclassOf(it.key) }.values.firstOrNull()
+                    providedInstanceMap.filter { parameterKClass.isSuperclassOf(it.key) }.values.firstOrNull()
                 if (providedInstance != null) {
                     return@map providedInstance
                 }
@@ -290,7 +319,7 @@ abstract class AbstractComponentRegistry : ComponentRegistry, KoinComponent {
         } else if (element.hasAnnotation<MutableNamed>()) {
             val key = element.findAnnotation<MutableNamed>()!!.key
             val qualifierProvider =
-                qualifierProviders[key] ?: throw NullPointerException("MutableNamedQualifier not found")
+                qualifierProviders[key] ?: throw QualifierNotFoundException()
             val provided = qualifierProvider.provideQualifier()
             StringQualifier(provided)
         } else {


### PR DESCRIPTION
원래의 QualifierProvider는 Component 들과는 독립적인 존재로 보고, 싱글톤 빈으로 선언된 Component 를 생성자 주입으로 받아올 수 없게 설계되어 있었습니다.

아래는 이 패치를 적용하기 전 작동하지 않는 코드입니다.

```kotlin
@Component
@HQSingleton(binds = [ShopConfig::class])
class ShopConfig(private val config: HQYamlConfiguration) : HQSimpleComponent, HQYamlConfiguration by config {
    fun getMessage(shopMessage: ShopMessage, transform: (String) -> String = { it }): String {
        return transform(config.getString(shopMessage.configKey))
    }
}

@QualifierProvider("shop.data-source-provider")
class ShopDataSourceQualifierProvider(private val config: ShopConfig) : MutableNamedProvider {
    override fun provideQualifier(): String {
        return "shop.${config.getDatabaseType()}"
    }
}
```

이 패치에서의 코드 변경 내용으로는, 빈을 선언할 때 QualifierProvider 의 key 를 통해 QualifierProvider 를 찾지 못하였을 경우 또한 인식하여 의존성을 주입하게 변경하였습니다.

또한, 위의 패치를 하다가 발견한 사항인데, 파라미터의 부모 타입 또한 인식하여 주입되는 문제가 있었습니다.
선언된 타입(bind 한 타입)으로만 주입되게 변경하였습니다.
