### PR TITLE
CommandContext 를 통한 CommandArgumentProvider 의 유기적 변경

### DIFF
--- a/modules/bukkit-command/build.gradle.kts
+++ b/modules/bukkit-command/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     compileOnly(libs.spigot.api)
     ksp(libs.koin.ksp.compiler)
     api(libs.kotlinx.coroutines.core)
+    api(libs.guava)
 
     testImplementationModule("bukkit", "test")
     testImplementation(libs.mockBukkit)

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/CommandContext.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/CommandContext.kt
@@ -1,0 +1,16 @@
+package kr.hqservice.framework.command.component
+
+import org.bukkit.command.CommandSender
+import kotlin.reflect.KClassifier
+
+interface CommandContext {
+    fun getCommandSender(): CommandSender
+
+    fun findArgument(key: String): String?
+
+    fun getArgument(key: String): String
+
+    fun getArguments(): Collection<String>
+
+    fun getArgumentsByType(kClassifier: KClassifier): Collection<String>
+}

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/ContextKey.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/ContextKey.kt
@@ -1,0 +1,5 @@
+package kr.hqservice.framework.command.component
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class ContextKey(val key: String)

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/HQCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/HQCommandArgumentProvider.kt
@@ -11,12 +11,12 @@ interface HQCommandArgumentProvider<T> : CommandArgumentProvider<T> {
      * 명령어의 결과를 반환합니다.
      * 만약 명령어 인자에 알맞은 인자가 오지 않았을 경우, false 를 리턴합니다.
      *
-     * @param commandSender 명령어 입력 주체
+     * @param context 이 메소드 실행 커맨드 context
      * @param string 입력 인자
      *
      * @return 인자 입력 결과
      */
-    fun getResult(commandSender: CommandSender, string: String?): Boolean
+    fun getResult(context: CommandContext, string: String?): Boolean
 
     /**
      * getResult 에서 false 를 반환받았을 때 반환될 메시지입니다.
@@ -36,7 +36,7 @@ interface HQCommandArgumentProvider<T> : CommandArgumentProvider<T> {
      *
      * @return 인자에 맞게끔 캐스팅 된 후 반환
      */
-    fun cast(string: String): T
+    fun cast(context: CommandContext, string: String): T
 
     /**
      * 명령어 인자 자동입력을 반환합니다.
@@ -55,12 +55,12 @@ interface HQSuspendCommandArgumentProvider<T> : CommandArgumentProvider<T> {
      * 명령어의 결과를 반환합니다.
      * 만약 명령어 인자에 알맞은 인자가 오지 않았을 경우, false 를 리턴합니다. 이 함수는 suspend 함수 입니다.
      *
-     * @param commandSender 명령어 입력 주체
+     * @param context 이 메소드 실행 커맨드 context
      * @param string 입력 인자
      *
      * @return 인자 입력 결과
      */
-    suspend fun getResult(commandSender: CommandSender, string: String?): Boolean
+    suspend fun getResult(context: CommandContext, string: String?): Boolean
 
     /**
      * getResult 에서 false 를 반환받았을 때 반환될 메시지입니다. 이 함수는 suspend 함수 입니다.
@@ -80,7 +80,7 @@ interface HQSuspendCommandArgumentProvider<T> : CommandArgumentProvider<T> {
      *
      * @return 인자에 맞게끔 캐스팅 된 후 반환
      */
-    suspend fun cast(string: String): T
+    suspend fun cast(context: CommandContext, string: String): T
 
     /**
      * 명령어 인자 자동입력을 반환합니다. 이 함수는 suspend 함수 입니다.

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/HQCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/HQCommandArgumentProvider.kt
@@ -41,13 +41,13 @@ interface HQCommandArgumentProvider<T> : CommandArgumentProvider<T> {
     /**
      * 명령어 인자 자동입력을 반환합니다.
      *
-     * @param commandSender 명령어 입력 주체
+     * @param context 이 메소드 실행 커맨드 context
      * @param location 명령어 입력 위치
      * @param argumentLabel @ArgumentLabel 을 통한 입력 인자 설명
      *
      * @return 자동완성을 추천할 문자열들
      */
-    fun getTabComplete(commandSender: CommandSender, location: Location?, argumentLabel: String? = null): List<String>
+    fun getTabComplete(context: CommandContext, location: Location?, argumentLabel: String? = null): List<String>
 }
 
 interface HQSuspendCommandArgumentProvider<T> : CommandArgumentProvider<T> {
@@ -85,11 +85,11 @@ interface HQSuspendCommandArgumentProvider<T> : CommandArgumentProvider<T> {
     /**
      * 명령어 인자 자동입력을 반환합니다. 이 함수는 suspend 함수 입니다.
      *
-     * @param commandSender 명령어 입력 주체
+     * @param context 이 메소드 실행 커맨드 context
      * @param location 명령어 입력 위치
      * @param argumentLabel @ArgumentLabel 을 통한 입력 인자 설명
      *
      * @return 자동완성을 추천할 문자열들
      */
-    suspend fun getTabComplete(commandSender: CommandSender, location: Location?, argumentLabel: String? = null): List<String>
+    suspend fun getTabComplete(context: CommandContext, location: Location?, argumentLabel: String? = null): List<String>
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/HQCommandTree.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/HQCommandTree.kt
@@ -91,16 +91,16 @@ abstract class HQCommandTree(
         return index to tree
     }
 
-    internal fun setup(repository: CommandRegistry) {
-        repository.getNodes(this::class).forEach { node ->
+    internal fun setup(registry: CommandRegistry) {
+        registry.getNodes(this::class).forEach { node ->
             node.getExecutors().forEach { (executorKey, executor) ->
                 commandExecutors[executorKey] = executor
             }
         }
 
-        repository.getTrees(this::class).forEach { tree ->
+        registry.getTrees(this::class).forEach { tree ->
             commandTrees[tree.label] = tree
-            tree.setup(repository)
+            tree.setup(registry)
         }
     }
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/handler/CommandRootComponentHandler.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/handler/CommandRootComponentHandler.kt
@@ -3,6 +3,7 @@ package kr.hqservice.framework.command.component.handler
 import kotlinx.coroutines.*
 import kr.hqservice.framework.bukkit.core.extension.colorize
 import kr.hqservice.framework.command.component.*
+import kr.hqservice.framework.command.component.impl.CommandContextImpl
 import kr.hqservice.framework.command.component.registry.CommandArgumentProviderRegistry
 import kr.hqservice.framework.command.component.registry.CommandRegistry
 import kr.hqservice.framework.coroutine.component.handler.CoroutineScopeComponentHandler
@@ -57,7 +58,10 @@ class CommandRootComponentHandler(
             .first { it.name == "commandMap" }
             .apply { isAccessible = true }
             .get(pluginManager) as CommandMap
-        commandMap.register(hqCommandRoot.getFallbackPrefix(), HQBukkitCommand(hqCommandRoot, commandCoroutineScope, mainCoroutineScope, argumentProviderRepository))
+        commandMap.register(
+            hqCommandRoot.getFallbackPrefix(),
+            HQBukkitCommand(hqCommandRoot, commandCoroutineScope, mainCoroutineScope, argumentProviderRepository)
+        )
     }
 
     private class HQBukkitCommand(
@@ -95,12 +99,14 @@ class CommandRootComponentHandler(
                     sender.sendMessage("&c플레이어만 사용할 수 있는 명령어입니다.".colorize())
                     return true
                 }
+
                 ConsoleCommandSender::class -> if (sender is ConsoleCommandSender) {
                     sender
                 } else {
                     sender.sendMessage("&c콘솔에서만 사용할 수 있는 명령어입니다.".colorize())
                     return true
                 }
+
                 else -> throw IllegalArgumentException("not command sender")
             }
 
@@ -129,7 +135,8 @@ class CommandRootComponentHandler(
                             withContext(coroutineContext) withContext@{
                                 val result = argumentProvider.getResult(senderInstance, argument)
                                 if (!result || argument == null) {
-                                    val failureMessage = argumentProvider.getFailureMessage(sender, argument, argumentLabel)
+                                    val failureMessage =
+                                        argumentProvider.getFailureMessage(sender, argument, argumentLabel)
                                     if (failureMessage != null) {
                                         senderInstance.sendMessage(failureMessage)
                                     }
@@ -143,12 +150,14 @@ class CommandRootComponentHandler(
                                 return@commandLaunch
                             }
                         }
+
                         is HQCommandArgumentProvider -> {
                             var isFailed = false
                             mainCoroutineScope.launch mainLaunch@{
                                 val result = argumentProvider.getResult(senderInstance, argument)
                                 if (!result || argument == null) {
-                                    val failureMessage = argumentProvider.getFailureMessage(sender, argument, argumentLabel)
+                                    val failureMessage =
+                                        argumentProvider.getFailureMessage(sender, argument, argumentLabel)
                                     if (failureMessage != null) {
                                         senderInstance.sendMessage("&c$failureMessage".colorize())
                                     }
@@ -180,9 +189,17 @@ class CommandRootComponentHandler(
                 if (function.isSuspend) {
                     if (executor.nodeInstance is CoroutineScope) {
                         withContext(executor.nodeInstance.coroutineContext) {
-                            executor.function.callSuspend(executor.nodeInstance, senderInstance, *arguments.toTypedArray())
+                            executor.function.callSuspend(
+                                executor.nodeInstance,
+                                senderInstance,
+                                *arguments.toTypedArray()
+                            )
                         }
-                    } else executor.function.callSuspend(executor.nodeInstance, senderInstance, *arguments.toTypedArray())
+                    } else executor.function.callSuspend(
+                        executor.nodeInstance,
+                        senderInstance,
+                        *arguments.toTypedArray()
+                    )
                 } else {
                     mainCoroutineScope.launch {
                         executor.function.call(executor.nodeInstance, senderInstance, *arguments.toTypedArray())
@@ -220,12 +237,26 @@ class CommandRootComponentHandler(
                         return emptyList()
                     }
                     val kParameter = executor.function.valueParameters[args.size - treeKey.size - 1]
-
+                    val parameterMap = args
+                        .toMutableList()
+                        .apply {
+                            repeat(treeKey.size + 1) {
+                                this.removeFirst()
+                            }
+                        }.mapIndexed { index, argument ->
+                            argument to executor.function.valueParameters[index + 1]
+                        }.toMap()
+                    val context = CommandContextImpl(sender, parameterMap)
                     return when (val argumentProvider = getArgumentProvider(kParameter)) {
                         is HQSuspendCommandArgumentProvider<*> -> runBlocking {
-                            argumentProvider.getTabComplete(sender, location, findArgumentLabel(kParameter))
+                            argumentProvider.getTabComplete(context, location, findArgumentLabel(kParameter))
                         }
-                        is HQCommandArgumentProvider<*> -> argumentProvider.getTabComplete(sender, location, findArgumentLabel(kParameter))
+
+                        is HQCommandArgumentProvider<*> -> argumentProvider.getTabComplete(
+                            context,
+                            location,
+                            findArgumentLabel(kParameter)
+                        )
                     }
                 } else {
                     return tree.getSuggestions()
@@ -249,7 +280,8 @@ class CommandRootComponentHandler(
         }
 
         private fun getArgumentProvider(parameter: KParameter): CommandArgumentProvider<*> {
-            val classifier = parameter.type.classifier ?: throw IllegalStateException("parameter type cannot be intersection type")
+            val classifier =
+                parameter.type.classifier ?: throw IllegalStateException("parameter type cannot be intersection type")
             return registry.getProvider(classifier)
         }
 

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/impl/CommandContextImpl.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/impl/CommandContextImpl.kt
@@ -1,0 +1,50 @@
+package kr.hqservice.framework.command.component.impl
+
+import com.google.common.collect.ArrayListMultimap
+import com.google.common.collect.Multimap
+import kr.hqservice.framework.command.component.CommandContext
+import kr.hqservice.framework.command.component.ContextKey
+import org.bukkit.command.CommandSender
+import kotlin.reflect.KClassifier
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.findAnnotation
+
+class CommandContextImpl(
+    private val commandSender: CommandSender,
+    private val parameterMap: Map<String, KParameter>
+) : CommandContext {
+    //                     contextKey, argument
+    private val arguments: Map<String, String> = parameterMap.map { (argument, kParameter)->
+        getContextKey(kParameter) to argument
+    }.toMap()
+
+    private val argumentsByType: Multimap<KClassifier, String> = ArrayListMultimap.create<KClassifier, String>().apply {
+        parameterMap.values.forEach { kParameter ->
+            this.put(kParameter.type.classifier, getContextKey(kParameter))
+        }
+    }
+
+    private fun getContextKey(kParameter: KParameter): String {
+        return kParameter.findAnnotation<ContextKey>()?.key ?: kParameter.name!!
+    }
+
+    override fun getCommandSender(): CommandSender {
+        return commandSender
+    }
+
+    override fun findArgument(key: String): String? {
+        return arguments[key]
+    }
+
+    override fun getArgument(key: String): String {
+        return arguments[key] ?: throw IllegalArgumentException()
+    }
+
+    override fun getArguments(): Collection<String> {
+        return arguments.values
+    }
+
+    override fun getArgumentsByType(kClassifier: KClassifier): Collection<String> {
+        return argumentsByType.get(kClassifier)
+    }
+}

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/BooleanCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/BooleanCommandArgumentProvider.kt
@@ -16,7 +16,7 @@ class BooleanCommandArgumentProvider : HQCommandArgumentProvider<Boolean> {
         return listOf(argumentLabel ?: "true/false")
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return string.equals("true", true) || string.equals("false", true)
     }
 
@@ -24,7 +24,7 @@ class BooleanCommandArgumentProvider : HQCommandArgumentProvider<Boolean> {
         return "${argumentLabel ?: "true/false"}을(를) 입력해야 합니다."
     }
 
-    override fun cast(string: String): Boolean {
+    override fun cast(context: CommandContext, string: String): Boolean {
         return string.toBoolean()
     }
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/BooleanCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/BooleanCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -8,7 +9,7 @@ import org.bukkit.command.CommandSender
 @Component
 class BooleanCommandArgumentProvider : HQCommandArgumentProvider<Boolean> {
     override fun getTabComplete(
-        commandSender: CommandSender,
+        context: CommandContext,
         location: Location?,
         argumentLabel: String?
     ): List<String> {

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/ChestRowCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/ChestRowCommandArgumentProvider.kt
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandSender
 
 @Component
 class ChestRowCommandArgumentProvider : HQCommandArgumentProvider<ChestRow> {
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         if (string == null) {
             return false
         }
@@ -20,7 +20,7 @@ class ChestRowCommandArgumentProvider : HQCommandArgumentProvider<ChestRow> {
         return "1~6 사이의 수를 입력해주세요."
     }
 
-    override fun cast(string: String): ChestRow {
+    override fun cast(context: CommandContext, string: String): ChestRow {
         return object : ChestRow {
             override val row: Int = string.toInt()
         }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/ChestRowCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/ChestRowCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -26,7 +27,7 @@ class ChestRowCommandArgumentProvider : HQCommandArgumentProvider<ChestRow> {
     }
 
     override fun getTabComplete(
-        commandSender: CommandSender,
+        context: CommandContext,
         location: Location?,
         argumentLabel: String?
     ): List<String> {

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/DoubleCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/DoubleCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -8,7 +9,7 @@ import org.bukkit.command.CommandSender
 @Component
 class DoubleCommandArgumentProvider : HQCommandArgumentProvider<Double> {
     override fun getTabComplete(
-        commandSender: CommandSender,
+        context: CommandContext,
         location: Location?,
         argumentLabel: String?
     ): List<String> {

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/DoubleCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/DoubleCommandArgumentProvider.kt
@@ -16,7 +16,7 @@ class DoubleCommandArgumentProvider : HQCommandArgumentProvider<Double> {
         return listOf(argumentLabel ?: "숫자")
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return string?.toDoubleOrNull() != null
     }
 
@@ -24,7 +24,7 @@ class DoubleCommandArgumentProvider : HQCommandArgumentProvider<Double> {
         return "${argumentLabel ?: "숫자"}을(를) 입력해야 합니다."
     }
 
-    override fun cast(string: String): Double {
+    override fun cast(context: CommandContext, string: String): Double {
         return string.toDouble()
     }
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/FloatCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/FloatCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -8,7 +9,7 @@ import org.bukkit.command.CommandSender
 @Component
 class FloatCommandArgumentProvider : HQCommandArgumentProvider<Float> {
     override fun getTabComplete(
-        commandSender: CommandSender,
+        context: CommandContext,
         location: Location?,
         argumentLabel: String?
     ): List<String> {

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/FloatCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/FloatCommandArgumentProvider.kt
@@ -16,7 +16,7 @@ class FloatCommandArgumentProvider : HQCommandArgumentProvider<Float> {
         return listOf(argumentLabel ?: "숫자")
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return string?.toFloatOrNull() != null
     }
 
@@ -24,7 +24,7 @@ class FloatCommandArgumentProvider : HQCommandArgumentProvider<Float> {
         return "${argumentLabel ?: "숫자"}을(를) 입력해야 합니다."
     }
 
-    override fun cast(string: String): Float {
+    override fun cast(context: CommandContext, string: String): Float {
         return string.toFloat()
     }
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/IntCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/IntCommandArgumentProvider.kt
@@ -12,7 +12,7 @@ class IntCommandArgumentProvider : HQCommandArgumentProvider<Int> {
         return listOf(argumentLabel ?: "정수")
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return string?.toIntOrNull() != null
     }
 
@@ -20,7 +20,7 @@ class IntCommandArgumentProvider : HQCommandArgumentProvider<Int> {
         return "${argumentLabel ?: "정수"}을(를) 입력해야 합니다."
     }
 
-    override fun cast(string: String): Int {
+    override fun cast(context: CommandContext, string: String): Int {
         return string.toInt()
     }
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/IntCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/IntCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -7,7 +8,7 @@ import org.bukkit.command.CommandSender
 
 @Component
 class IntCommandArgumentProvider : HQCommandArgumentProvider<Int> {
-    override fun getTabComplete(commandSender: CommandSender, location: Location?, argumentLabel: String?): List<String> {
+    override fun getTabComplete(context: CommandContext, location: Location?, argumentLabel: String?): List<String> {
         return listOf(argumentLabel ?: "정수")
     }
 

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/LongCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/LongCommandArgumentProvider.kt
@@ -16,7 +16,7 @@ class LongCommandArgumentProvider : HQCommandArgumentProvider<Long> {
         return listOf(argumentLabel ?: "숫자")
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return string?.toLongOrNull() != null
     }
 
@@ -24,7 +24,7 @@ class LongCommandArgumentProvider : HQCommandArgumentProvider<Long> {
         return "${argumentLabel ?: "숫자"}을(를) 입력해야 합니다."
     }
 
-    override fun cast(string: String): Long {
+    override fun cast(context: CommandContext, string: String): Long {
         return string.toLong()
     }
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/LongCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/LongCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -8,7 +9,7 @@ import org.bukkit.command.CommandSender
 @Component
 class LongCommandArgumentProvider : HQCommandArgumentProvider<Long> {
     override fun getTabComplete(
-        commandSender: CommandSender,
+        context: CommandContext,
         location: Location?,
         argumentLabel: String?
     ): List<String> {

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/PlayerCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/PlayerCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -10,7 +11,7 @@ import org.bukkit.entity.Player
 @Component
 class PlayerCommandArgumentProvider(private val server: Server) : HQCommandArgumentProvider<Player> {
     override fun getTabComplete(
-        commandSender: CommandSender,
+        context: CommandContext,
         location: Location?,
         argumentLabel: String?
     ): List<String> {

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/PlayerCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/PlayerCommandArgumentProvider.kt
@@ -18,7 +18,7 @@ class PlayerCommandArgumentProvider(private val server: Server) : HQCommandArgum
         return server.onlinePlayers.map { it.name }
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return string?.let { server.getPlayerExact(it) } != null
     }
 
@@ -26,7 +26,7 @@ class PlayerCommandArgumentProvider(private val server: Server) : HQCommandArgum
         return "접속중인 ${argumentLabel ?: "플레이어"}의 이름을 입력해야 합니다."
     }
 
-    override fun cast(string: String): Player {
+    override fun cast(context: CommandContext, string: String): Player {
         return server.getPlayerExact(string) ?: throw NullPointerException("player $string is null")
     }
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/StringCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/StringCommandArgumentProvider.kt
@@ -1,5 +1,6 @@
 package kr.hqservice.framework.command.component.providers
 
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -7,7 +8,7 @@ import org.bukkit.command.CommandSender
 
 @Component
 class StringCommandArgumentProvider : HQCommandArgumentProvider<String> {
-    override fun getTabComplete(commandSender: CommandSender, location: Location?, argumentLabel: String?): List<String> {
+    override fun getTabComplete(context: CommandContext, location: Location?, argumentLabel: String?): List<String> {
         return listOf(argumentLabel ?: "문자열")
     }
 

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/StringCommandArgumentProvider.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/component/providers/StringCommandArgumentProvider.kt
@@ -12,7 +12,7 @@ class StringCommandArgumentProvider : HQCommandArgumentProvider<String> {
         return listOf(argumentLabel ?: "문자열")
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return true
     }
 
@@ -20,7 +20,7 @@ class StringCommandArgumentProvider : HQCommandArgumentProvider<String> {
         return "${argumentLabel ?: "문자열"}을(를) 입력해야 합니다."
     }
 
-    override fun cast(string: String): String {
+    override fun cast(context: CommandContext, string: String): String {
         return string
     }
 }

--- a/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/PluginDescriptionCommand.kt
+++ b/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/PluginDescriptionCommand.kt
@@ -2,14 +2,14 @@ package kr.hqservice.framework.command
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kr.hqservice.framework.bukkit.core.HQBukkitPlugin
 import kr.hqservice.framework.bukkit.core.extension.colorize
-import kr.hqservice.framework.command.component.CommandExecutor
-import kr.hqservice.framework.command.component.HQCommandNode
-import kr.hqservice.framework.command.component.ParentCommand
+import kr.hqservice.framework.command.component.*
 import kr.hqservice.framework.global.core.component.Component
 import kr.hqservice.framework.global.core.extension.toHumanReadable
 import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
 import kotlin.coroutines.CoroutineContext
 
 @Component
@@ -37,26 +37,26 @@ class PluginDescriptionCommand : HQCommandNode(), CoroutineScope {
     fun sendAuthors(sender: CommandSender, plugin: HQBukkitPlugin) {
         sender.sendMessage("&a개발자: &7${plugin.description.authors.toHumanReadable()}".colorize())
     }
-//
-//    @CommandExecutor(
-//        label = "testgreedy",
-//        description = "testgreedy",
-//        isOp = true,
-//        priority = 999
-//    )
-//    fun testGreedyArguments(sender: CommandSender, @ArgumentLabel("문자잉") string: String, @ContextKey("intint") int: Int, plugin: HQBukkitPlugin, stringNullable: String? = "default", intNullable: Int?) {
-//        sender.sendMessage("$string, $int, ${plugin.name}, $stringNullable, $intNullable")
-//    }
-//
-//    @CommandExecutor(
-//        label = "testgreedy11",
-//        description = "testgreedy11",
-//        isOp = true,
-//        priority = 999
-//    )
-//    suspend fun testGreedyArguments2(sender: Player, @ArgumentLabel("문자잉2") string: String, int: Int, plugin: HQBukkitPlugin) {
-//        sender.sendMessage("$string, $int, ${plugin.name} 1111")
-//        delay(3000)
-//        sender.sendMessage("$string, $int, ${plugin.name}")
-//    }
+
+    @CommandExecutor(
+        label = "testgreedy",
+        description = "testgreedy",
+        isOp = true,
+        priority = 999
+    )
+    fun testGreedyArguments(sender: CommandSender, @ArgumentLabel("문자잉") string: String, @ContextKey("intint") int: Int, plugin: HQBukkitPlugin, stringNullable: String? = "default", intNullable: Int?) {
+        sender.sendMessage("$string, $int, ${plugin.name}, $stringNullable, $intNullable")
+    }
+
+    @CommandExecutor(
+        label = "testgreedy11",
+        description = "testgreedy11",
+        isOp = true,
+        priority = 999
+    )
+    suspend fun testGreedyArguments2(sender: Player, @ArgumentLabel("문자잉2") string: String, int: Int, plugin: HQBukkitPlugin) {
+        sender.sendMessage("$string, $int, ${plugin.name} 1111")
+        delay(3000)
+        sender.sendMessage("$string, $int, ${plugin.name}")
+    }
 }

--- a/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/PluginDescriptionCommand.kt
+++ b/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/PluginDescriptionCommand.kt
@@ -2,17 +2,14 @@ package kr.hqservice.framework.command
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kr.hqservice.framework.bukkit.core.HQBukkitPlugin
 import kr.hqservice.framework.bukkit.core.extension.colorize
-import kr.hqservice.framework.command.component.ArgumentLabel
 import kr.hqservice.framework.command.component.CommandExecutor
 import kr.hqservice.framework.command.component.HQCommandNode
 import kr.hqservice.framework.command.component.ParentCommand
 import kr.hqservice.framework.global.core.component.Component
 import kr.hqservice.framework.global.core.extension.toHumanReadable
 import org.bukkit.command.CommandSender
-import org.bukkit.entity.Player
 import kotlin.coroutines.CoroutineContext
 
 @Component
@@ -40,26 +37,26 @@ class PluginDescriptionCommand : HQCommandNode(), CoroutineScope {
     fun sendAuthors(sender: CommandSender, plugin: HQBukkitPlugin) {
         sender.sendMessage("&a개발자: &7${plugin.description.authors.toHumanReadable()}".colorize())
     }
-
-    @CommandExecutor(
-        label = "testgreedy",
-        description = "testgreedy",
-        isOp = true,
-        priority = 999
-    )
-    fun testGreedyArguments(sender: CommandSender, @ArgumentLabel("문자잉") string: String, int: Int, plugin: HQBukkitPlugin, stringNullable: String? = "default", intNullable: Int?) {
-        sender.sendMessage("$string, $int, ${plugin.name}, $stringNullable, $intNullable")
-    }
-
-    @CommandExecutor(
-        label = "testgreedy11",
-        description = "testgreedy11",
-        isOp = true,
-        priority = 999
-    )
-    suspend fun testGreedyArguments2(sender: Player, @ArgumentLabel("문자잉2") string: String, int: Int, plugin: HQBukkitPlugin) {
-        sender.sendMessage("$string, $int, ${plugin.name} 1111")
-        delay(3000)
-        sender.sendMessage("$string, $int, ${plugin.name}")
-    }
+//
+//    @CommandExecutor(
+//        label = "testgreedy",
+//        description = "testgreedy",
+//        isOp = true,
+//        priority = 999
+//    )
+//    fun testGreedyArguments(sender: CommandSender, @ArgumentLabel("문자잉") string: String, @ContextKey("intint") int: Int, plugin: HQBukkitPlugin, stringNullable: String? = "default", intNullable: Int?) {
+//        sender.sendMessage("$string, $int, ${plugin.name}, $stringNullable, $intNullable")
+//    }
+//
+//    @CommandExecutor(
+//        label = "testgreedy11",
+//        description = "testgreedy11",
+//        isOp = true,
+//        priority = 999
+//    )
+//    suspend fun testGreedyArguments2(sender: Player, @ArgumentLabel("문자잉2") string: String, int: Int, plugin: HQBukkitPlugin) {
+//        sender.sendMessage("$string, $int, ${plugin.name} 1111")
+//        delay(3000)
+//        sender.sendMessage("$string, $int, ${plugin.name}")
+//    }
 }

--- a/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/providers/HQBukkitPluginCommandArgumentProvider.kt
+++ b/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/providers/HQBukkitPluginCommandArgumentProvider.kt
@@ -2,6 +2,7 @@ package kr.hqservice.framework.command.providers
 
 import kr.hqservice.framework.bukkit.core.HQBukkitPlugin
 import kr.hqservice.framework.bukkit.core.extension.colorize
+import kr.hqservice.framework.command.component.CommandContext
 import kr.hqservice.framework.command.component.HQCommandArgumentProvider
 import kr.hqservice.framework.global.core.component.Component
 import org.bukkit.Location
@@ -11,7 +12,7 @@ import org.bukkit.command.CommandSender
 @Component
 class HQBukkitPluginCommandArgumentProvider(private val server: Server) : HQCommandArgumentProvider<HQBukkitPlugin> {
     override fun getTabComplete(
-        commandSender: CommandSender,
+        context: CommandContext,
         location: Location?,
         argumentLabel: String?
     ): List<String> {

--- a/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/providers/HQBukkitPluginCommandArgumentProvider.kt
+++ b/modules/bukkit-dist/src/main/kotlin/kr/hqservice/framework/command/providers/HQBukkitPluginCommandArgumentProvider.kt
@@ -21,7 +21,7 @@ class HQBukkitPluginCommandArgumentProvider(private val server: Server) : HQComm
         }
     }
 
-    override fun getResult(commandSender: CommandSender, string: String?): Boolean {
+    override fun getResult(context: CommandContext, string: String?): Boolean {
         return server.pluginManager.plugins.filterIsInstance<HQBukkitPlugin>().any {
             it.name.lowercase() == string?.lowercase()
         }
@@ -35,7 +35,7 @@ class HQBukkitPluginCommandArgumentProvider(private val server: Server) : HQComm
         }
     }
 
-    override fun cast(string: String): HQBukkitPlugin {
+    override fun cast(context: CommandContext, string: String): HQBukkitPlugin {
         return server.pluginManager.plugins.filterIsInstance<HQBukkitPlugin>().first { it.name.lowercase() == string.lowercase() }
     }
 }


### PR DESCRIPTION
기존 CommandArgumentProvider 는 자동완성의 경우 앞의 인자, 실행을 위한 캐스팅의 경우 다른 인자 들이 영향을 미치지 않았습니다.
이번 패치로 인해 CommandArgumentProvider 는 CommandContext 를 제공받게되고, 다른 인자들과의 유기적 상호작용이 되게 되었습니다.

@ContextKey 로 CommandContext 에서 argument 를 구할 때 key 를 명시해줄 수 있습니다.
아래는 CommandExecutor 의 예제입니다.

```kotlin
//...
    @CommandExecutor(
        label = "testgreedy",
        description = "testgreedy",
        isOp = true,
        priority = 999
    )
    fun testGreedyArguments(sender: CommandSender, @ArgumentLabel("문자잉") string: String, @ContextKey("intint") int: Int, plugin: HQBukkitPlugin, stringNullable: String? = "default", intNullable: Int?) {
        sender.sendMessage("$string, $int, ${plugin.name}, $stringNullable, $intNullable")
    }
//...   
 ```
 
 이런식으로 명시된 인자를 commandContext.getArgument("intint") 를 통하여
 CommandArgumentProvider 에서 자동완성을 구하거나 캐스팅, 결과를 구할 때 사용할 수 있습니다. 