### PR TITLE
Virtual Camera

### DIFF
--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/AbstractVirtualEntity.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/AbstractVirtualEntity.kt
@@ -5,10 +5,13 @@ import kr.hqservice.framework.nms.Version
 import kr.hqservice.framework.nms.extension.getNmsItemStack
 import kr.hqservice.framework.nms.wrapper.NmsReflectionWrapper
 import kr.hqservice.framework.nms.virtual.classes.VirtualEntityClasses
+import kr.hqservice.framework.nms.virtual.factory.VirtualViewFactory
+import kr.hqservice.framework.nms.virtual.factory.impl.SingleVirtualFactory
 import kr.hqservice.framework.nms.virtual.message.VirtualListMessage
 import kr.hqservice.framework.nms.virtual.message.VirtualMessageImpl
 import kr.hqservice.framework.nms.wrapper.getFunction
 import org.bukkit.Location
+import org.bukkit.entity.Player
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
@@ -23,7 +26,7 @@ abstract class AbstractVirtualEntity(
 
     private var state: Byte = 0x7
     private var itemContainer: List<Any>? = null
-    protected abstract fun getEntity(): Any
+    abstract fun getEntity(): Any
     private fun entityInitialize() {
         if(name.isNotEmpty()) {
             setName(name.colorize())

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/inner/VirtualCamera.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/inner/VirtualCamera.kt
@@ -1,0 +1,42 @@
+package kr.hqservice.framework.nms.virtual.entity.inner
+
+import kr.hqservice.framework.nms.Version
+import kr.hqservice.framework.nms.virtual.AbstractVirtualEntity
+import kr.hqservice.framework.nms.virtual.Virtual
+import kr.hqservice.framework.nms.virtual.VirtualMessage
+import kr.hqservice.framework.nms.virtual.message.VirtualListMessage
+import kr.hqservice.framework.nms.wrapper.NmsReflectionWrapper
+import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class VirtualCamera(
+    private val player: Player,
+    private val virtualEntity: AbstractVirtualEntity?
+) : Virtual, KoinComponent {
+    private val reflectionWrapper: NmsReflectionWrapper by inject()
+    private val entityClass = reflectionWrapper.getNmsClass("Entity", Version.V_15.handle("world.entity"))
+    private val stateChangePacketClass = reflectionWrapper.getNmsClass("PacketPlayOutGameStateChange", Version.V_15.handle("network.protocol.game"))
+    private val changeGameModeType = reflectionWrapper.getStaticField(stateChangePacketClass, "d").call()!!
+    private val cameraPacketClass = reflectionWrapper.getNmsClass("PacketPlayOutCamera", Version.V_15.handle("network.protocol.game"))
+
+    override fun createVirtualMessage(): VirtualMessage {
+        val stateChangePacket: Any
+        val cameraPacket: Any
+        if(virtualEntity != null) {
+            stateChangePacket =
+                stateChangePacketClass.java.getConstructor(changeGameModeType::class.java, Float::class.java)
+                    .newInstance(changeGameModeType, 3f)
+            cameraPacket = cameraPacketClass.java.getConstructor(entityClass.java)
+                .newInstance(virtualEntity.getEntity())
+        } else {
+            val serverPlayer = reflectionWrapper.getEntityPlayer(player)
+            stateChangePacket =
+                stateChangePacketClass.java.getConstructor(changeGameModeType::class.java, Float::class.java)
+                    .newInstance(changeGameModeType, player.gameMode.value.toFloat())
+            cameraPacket = cameraPacketClass.java.getConstructor(entityClass.java)
+                .newInstance(serverPlayer)
+        }
+        return VirtualListMessage(listOf(stateChangePacket, cameraPacket))
+    }
+}

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/inner/VirtualCamera.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/inner/VirtualCamera.kt
@@ -7,14 +7,12 @@ import kr.hqservice.framework.nms.virtual.VirtualMessage
 import kr.hqservice.framework.nms.virtual.message.VirtualListMessage
 import kr.hqservice.framework.nms.wrapper.NmsReflectionWrapper
 import org.bukkit.entity.Player
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 
 class VirtualCamera(
     private val player: Player,
-    private val virtualEntity: AbstractVirtualEntity?
-) : Virtual, KoinComponent {
-    private val reflectionWrapper: NmsReflectionWrapper by inject()
+    private val virtualEntity: AbstractVirtualEntity?,
+    private val reflectionWrapper: NmsReflectionWrapper
+) : Virtual {
     private val entityClass = reflectionWrapper.getNmsClass("Entity", Version.V_15.handle("world.entity"))
     private val stateChangePacketClass = reflectionWrapper.getNmsClass("PacketPlayOutGameStateChange", Version.V_15.handle("network.protocol.game"))
     private val changeGameModeType = reflectionWrapper.getStaticField(stateChangePacketClass, "d").call()!!

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/VirtualFactory.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/VirtualFactory.kt
@@ -15,6 +15,8 @@ interface VirtualFactory {
 
     fun getViewers(): List<Player>
 
+    suspend fun setCamera(virtualEntity: AbstractVirtualEntity?)
+
     suspend fun inventory(containerFactoryScope: VirtualContainerFactory.() -> Unit)
 
     suspend fun updateEntity(virtualEntity: AbstractVirtualEntity)

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/GlobalVirtualFactory.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/GlobalVirtualFactory.kt
@@ -30,7 +30,7 @@ class GlobalVirtualFactory(
 
     override suspend fun setCamera(virtualEntity: AbstractVirtualEntity?) {
         receivers.forEach {
-            val virtualCamera = VirtualCamera(it, virtualEntity)
+            val virtualCamera = VirtualCamera(it, virtualEntity, reflectionWrapper)
             reflectionWrapper.sendPacket(it, virtualCamera)
         }
     }

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/GlobalVirtualFactory.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/GlobalVirtualFactory.kt
@@ -1,6 +1,7 @@
 package kr.hqservice.framework.nms.virtual.factory.impl
 
 import kr.hqservice.framework.nms.virtual.AbstractVirtualEntity
+import kr.hqservice.framework.nms.virtual.entity.inner.VirtualCamera
 import kr.hqservice.framework.nms.wrapper.NmsReflectionWrapper
 import kr.hqservice.framework.nms.virtual.factory.VirtualFactory
 import kr.hqservice.framework.nms.virtual.factory.VirtualContainerFactory
@@ -25,6 +26,13 @@ class GlobalVirtualFactory(
 
     override fun getViewers(): List<Player> {
         return receivers
+    }
+
+    override suspend fun setCamera(virtualEntity: AbstractVirtualEntity?) {
+        receivers.forEach {
+            val virtualCamera = VirtualCamera(it, virtualEntity)
+            reflectionWrapper.sendPacket(it, virtualCamera)
+        }
     }
 
     override suspend fun inventory(containerFactoryScope: VirtualContainerFactory.() -> Unit) {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/SingleVirtualFactory.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/SingleVirtualFactory.kt
@@ -31,7 +31,7 @@ class SingleVirtualFactory(
     }
 
     override suspend fun setCamera(virtualEntity: AbstractVirtualEntity?) {
-        val virtualCamera = VirtualCamera(receiver, virtualEntity)
+        val virtualCamera = VirtualCamera(receiver, virtualEntity, reflectionWrapper)
         reflectionWrapper.sendPacket(receiver, virtualCamera)
     }
 

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/SingleVirtualFactory.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/factory/impl/SingleVirtualFactory.kt
@@ -2,6 +2,7 @@ package kr.hqservice.framework.nms.virtual.factory.impl
 
 import kr.hqservice.framework.nms.service.NmsService
 import kr.hqservice.framework.nms.virtual.AbstractVirtualEntity
+import kr.hqservice.framework.nms.virtual.entity.inner.VirtualCamera
 import kr.hqservice.framework.nms.wrapper.NmsReflectionWrapper
 import kr.hqservice.framework.nms.virtual.factory.VirtualFactory
 import kr.hqservice.framework.nms.virtual.factory.VirtualContainerFactory
@@ -27,6 +28,11 @@ class SingleVirtualFactory(
 
     override fun getViewers(): List<Player> {
         return listOf(receiver)
+    }
+
+    override suspend fun setCamera(virtualEntity: AbstractVirtualEntity?) {
+        val virtualCamera = VirtualCamera(receiver, virtualEntity)
+        reflectionWrapper.sendPacket(receiver, virtualCamera)
     }
 
     override suspend fun inventory(containerFactoryScope: VirtualContainerFactory.() -> Unit) {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/NmsReflectionWrapper.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/NmsReflectionWrapper.kt
@@ -33,6 +33,8 @@ interface NmsReflectionWrapper {
 
     fun getField(clazz: KClass<*>, fieldName: String, vararg handlers: VersionHandler): KCallable<*>
 
+    fun getStaticField(clazz: KClass<*>, staticFieldName: String, vararg handlers: VersionHandler): KCallable<*>
+
     suspend fun sendPacket(player: Player, vararg virtual: Virtual)
 
     suspend fun sendPacket(players: List<Player>, vararg virtual: Virtual)

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/reflect/NmsReflectionWrapperImpl.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/reflect/NmsReflectionWrapperImpl.kt
@@ -160,6 +160,14 @@ class NmsReflectionWrapperImpl(
         } ?: throw IllegalArgumentException()
     }
 
+    override fun getStaticField(clazz: KClass<*>, staticFieldName: String, vararg handlers: VersionHandler): KCallable<*> {
+        val type = handlers.sortedByDescending { it.getVersion().ordinal }
+            .firstOrNull { it.getVersion().support(version, minorVersion) }?.getName() ?: staticFieldName
+        return clazz.staticProperties.firstOrNull {
+            it.name == type
+        } ?: throw IllegalArgumentException()
+    }
+
     private fun getFunction(
         clazz: KClass<*>,
         functions: Collection<KCallable<*>>,


### PR DESCRIPTION
Virtual Entity 의 시야를 플레이어가 공유받을 수 있게됩니다.
Camera 는 Virtual 환경에서만 동작하기 때문에 별도의 Handler 를 구성하여 제어해야합니다.
( 그렇지 않으면 플레이어는 접속을 종료하기 전 까지 원래의 시야로 돌아올 수 없게 됩니다. )

> 아래는 간단한 예제 코드와 인게임 테스트 이미지입니다.
```kotlin
val am = VirtualArmorStand(sender.location)
sender.virtual {
    updateEntity(am)
    setCamera(am)
    while(!sender.isSneaking) {
        am.setLocation(am.getLocation().add(.0, .05, .0,))
        updateEntity(am)
        delay(50)
    }
    setCamera(null)
    am.destroy()
    updateEntity(am)
}
```
![녹화_2023_07_01_03_07_00_272](https://github.com/HighQualityService/HQFramework/assets/47964442/c9618eea-96d6-4604-a53b-eefeee9f8cd1)

